### PR TITLE
Remove bind mount build artifact export

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 test
 docker-compose.test.yml
 RPMS
+build.sh

--- a/Dockerfile.rpmbuild
+++ b/Dockerfile.rpmbuild
@@ -11,9 +11,7 @@ ARG USER_GID=1000
 RUN groupadd -o -g $USER_GID build && useradd -o -u $USER_UID -g $USER_GID -d /build --create-home build
 WORKDIR /build
 
-# Output directory
-RUN mkdir /RPMS && chown $USER_UID:$USER_GID /RPMS
-VOLUME ["/RPMS"]
+RUN chmod 755 /build
 
 # Build & install the libjwt rpm
 COPY rpm_specs/libjwt.spec /build/rpm_specs/libjwt.spec
@@ -32,4 +30,7 @@ RUN chown -R $USER_UID:$USER_GID /build/mod_proxy_jwt_auth
 
 USER build
 # The cp is to make the path friendlier and to allow the image built libjwt to be copied out
-CMD rpmbuild -ba rpm_specs/mod_proxy_jwt_auth.spec && cp /build/rpmbuild/RPMS/* /RPMS -rv
+RUN rpmbuild -ba rpm_specs/mod_proxy_jwt_auth.spec 
+USER root
+RUN mkdir -p /RPMS && cp -r /build/rpmbuild/RPMS/* /RPMS && chmod -R 755 /RPMS
+CMD ["ls", "-al", "/RPMS"]

--- a/build.sh
+++ b/build.sh
@@ -3,18 +3,35 @@
 # NOTE: This does not clean up Docker images
 # WARNING: Must be run from the repo dir
 
+set -x
+
 RPMDIR="$(pwd)/RPMS"
 if [ ! -d $RPMDIR ]; then
     mkdir $RPMDIR || exit 1
 fi
 
-docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f Dockerfile.rpmbuild -t mod_proxy_jwt_auth:rpmbuild . || exit 1
-docker run --rm -v $RPMDIR:/RPMS mod_proxy_jwt_auth:rpmbuild || exit 1
+export DOCKER_COMPOSE="docker-compose -f docker-compose.test.yml -p build${RANDOM}${RANDOM}${RANDOM}"
 
-docker-compose -f docker-compose.test.yml build || exit 1
-docker-compose -f docker-compose.test.yml run test_suite bundle exec rspec -fd
+image_name=mod_proxy_jwt_auth:rpmbuild
+if [ ! -z "$DEV_EAST_REPO" ]; then
+    cache_image_name=${DEV_EAST_REPO}:mod_proxy_jwt_auth-cache
+    docker_args=-t $cache_image_name
+fi
+container_name="mod_proxy_jwt_auth-${RANDOM}${RANDOM}"
+
+[ ! -z "$DEV_EAST_REPO" ] && docker pull $cache_image_name || true
+DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 -f Dockerfile.rpmbuild -t $image_name $docker_args .
+[ ! -z "$DEV_EAST_REPO" ] && docker push $cache_image_name || true
+docker run --name $container_name $image_name
+docker cp $container_name:/RPMS/. $RPMDIR
+docker rm $container_name
+
+$DOCKER_COMPOSE down -fsv
+$DOCKER_COMPOSE build || exit 1
+$DOCKER_COMPOSE run test_suite bundle exec rspec -fd
 rv=$?
+[ $rv ] || $DOCKER_COMPOSE logs
 # Always run the down & rm steps to clean up
-docker-compose -f docker-compose.test.yml down
-docker-compose -f docker-compose.test.yml rm -fv
+$DOCKER_COMPOSE down
+$DOCKER_COMPOSE rm -fv
 exit $rv


### PR DESCRIPTION
This changes from bind-mounting to using `docker cp` to get around a myriad of file system permission issues